### PR TITLE
Fix mobile menu clipping when opened after scrolling

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -461,9 +461,14 @@ img {
 		border-bottom-color: $line-soft;
 	}
 
+	// While the menu is open the bar is solid, so the blur is not needed —
+	// and it must be off: backdrop-filter turns the nav into the containing
+	// block for the fixed menu panel, clipping it to the bar's height.
 	&.is-open {
 		background: #070a08;
 		border-bottom-color: $line-soft;
+		backdrop-filter: none;
+		-webkit-backdrop-filter: none;
 	}
 }
 


### PR DESCRIPTION
backdrop-filter on the scrolled navbar makes it the containing block for fixed-position descendants, so the menu panel's inset resolved against the 64px bar instead of the viewport and collapsed to ~76px. Disable the blur while the menu is open (the bar is solid then anyway).

https://claude.ai/code/session_01PcqboP3jRvBnts1tqztpKF