### PR TITLE
Add RSS feed for projects

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -33,7 +33,8 @@ const year = new Date().getFullYear();
                     <li><a href="https://status.joshrandall.net">Uptime <i class="ext fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i></a></li>
                     <li><a href="https://gitlab.joshrandall.net/josh">GitLab <i class="ext fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i></a></li>
                     <li><a href="https://github.com/joshrandall8478/joshrandall8478.github.io">Site source <i class="ext fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i></a></li>
-                    <li><a href="/rss.xml">RSS feed</a></li>
+                    <li><a href="/rss.xml">RSS — Posts</a></li>
+                    <li><a href="/projects-rss.xml">RSS — Projects</a></li>
                 </ul>
             </nav>
         </div>

--- a/src/pages/projects-rss.xml.js
+++ b/src/pages/projects-rss.xml.js
@@ -1,0 +1,51 @@
+// RSS feed for projects, generated at build time.
+
+const projectImports = import.meta.glob('./projects/*.md', { eager: true });
+const SITE = 'https://joshrandall.net';
+
+const escapeXml = (value) =>
+    String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+
+export async function GET() {
+    const projects = Object.values(projectImports)
+        .filter((project) => !project.frontmatter.draft && !project.frontmatter.unlisted)
+        .sort((a, b) => Date.parse(b.frontmatter.date) - Date.parse(a.frontmatter.date));
+
+    const items = projects
+        .map((project) => {
+            const url = `${SITE}${project.url}/`;
+            const date = new Date(project.frontmatter.date);
+            const pubDate = Number.isNaN(date.getTime()) ? '' : `<pubDate>${date.toUTCString()}</pubDate>`;
+            return [
+                '<item>',
+                `<title>${escapeXml(project.frontmatter.title)}</title>`,
+                `<link>${url}</link>`,
+                `<guid>${url}</guid>`,
+                pubDate,
+                `<description>${escapeXml(project.frontmatter.subtitle)}</description>`,
+                '</item>',
+            ].join('');
+        })
+        .join('\n');
+
+    const xml = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<rss version="2.0">',
+        '<channel>',
+        '<title>Joshua Randall — Projects</title>',
+        `<link>${SITE}</link>`,
+        '<description>Projects by Joshua Randall — software, homelab, and hardware builds.</description>',
+        '<language>en-us</language>',
+        items,
+        '</channel>',
+        '</rss>',
+    ].join('\n');
+
+    return new Response(xml, {
+        headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+    });
+}


### PR DESCRIPTION
## Summary
Added a dedicated RSS feed for projects to allow users to subscribe to project updates separately from blog posts.

## Changes
- **New RSS feed endpoint** (`src/pages/projects-rss.xml.js`): Created a build-time generated RSS feed that aggregates all published projects
  - Filters out draft and unlisted projects
  - Sorts projects by date in descending order
  - Includes proper XML escaping for special characters
  - Uses project title, subtitle, URL, and date in feed items
  
- **Updated footer navigation** (`src/components/Footer.astro`): 
  - Clarified existing RSS feed link as "RSS — Posts"
  - Added new link to "RSS — Projects" feed

## Implementation Details
- The RSS feed is generated at build time using Astro's `import.meta.glob()` to load all markdown project files
- Implements XML escaping utility to safely handle special characters in project titles and subtitles
- Validates publication dates and only includes `<pubDate>` element for valid dates
- Returns proper `application/rss+xml` content type header

https://claude.ai/code/session_01Vs4z7KcKS4MrK8sUCwHzjp