### PR TITLE
Add reading time estimates to project articles

### DIFF
--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -4,11 +4,12 @@ import BaseHead from '../components/BaseHead.astro';
 import TopBar from '../components/topbar.astro';
 import Footer from '../components/Footer.astro';
 import { tools } from '../maps/tools.json';
-import { formatDate } from '../utils/content.js';
+import { formatDate, readingTime } from '../utils/content.js';
 
-const { frontmatter } = Astro.props;
+const { frontmatter, rawContent } = Astro.props;
 const currentPath = frontmatter.url ?? "";
 const updated = frontmatter.date !== frontmatter.originalDate ? frontmatter.date : null;
+const readTime = readingTime(rawContent);
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -38,6 +39,7 @@ const updated = frontmatter.date !== frontmatter.originalDate ? frontmatter.date
                     <div class="article__meta">
                         <span><i class="fa-regular fa-calendar" aria-hidden="true"></i>Posted {formatDate(frontmatter.originalDate)}</span>
                         {updated && <span><i class="fa-solid fa-rotate" aria-hidden="true"></i>Updated {formatDate(updated)}</span>}
+                        {readTime && <span><i class="fa-regular fa-clock" aria-hidden="true"></i>{readTime} min read</span>}
                     </div>
                     {frontmatter.tools?.length > 0 && (
                         <div class="article__tools">

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -2,7 +2,7 @@
 import '../styles/blog-list.scss';
 import Layout from '../layouts/MainLayout.astro';
 import ArticleCard from '../components/ArticleCard.astro';
-import { published } from '../utils/content.js';
+import { published, readingTime } from '../utils/content.js';
 
 const projects = published(import.meta.glob('./projects/*.md', { eager: true }));
 const currentPath = Astro.url.pathname;
@@ -30,6 +30,7 @@ const currentPath = Astro.url.pathname;
                     date={project.frontmatter.date}
                     description={project.frontmatter.subtitle}
                     tools={project.frontmatter.tools}
+                    readTime={readingTime(project)}
                     eager={i < 6}
                 />
             ))}


### PR DESCRIPTION
## Summary
This PR adds reading time estimates to project articles, displaying them alongside publication and update dates in both the project detail view and project listing cards.

## Key Changes
- Imported `readingTime` utility function from `src/utils/content.js` in both `ProjectLayout.astro` and `projects.astro`
- Updated `ProjectLayout.astro` to:
  - Accept `rawContent` from Astro props
  - Calculate reading time using the `readingTime()` function
  - Display reading time in the article metadata section with a clock icon
- Updated `projects.astro` to:
  - Calculate reading time for each project
  - Pass `readTime` prop to `ArticleCard` component for display in project listings

## Implementation Details
- Reading time is calculated from the raw markdown content and displayed as "X min read"
- The reading time estimate appears in the article metadata alongside the posted and updated dates
- The feature is integrated into both the detailed project view and the project listing cards

https://claude.ai/code/session_011LDgbS9LK51wvb17z8e5Uy