### PR TITLE
Show reading time on index latest project card

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -135,6 +135,7 @@ try {
                     date={latestProject.frontmatter.date}
                     description={latestProject.frontmatter.subtitle}
                     tools={latestProject.frontmatter.tools}
+                    readTime={readingTime(latestProject)}
                     eager
                 />
             </div>


### PR DESCRIPTION
The home page's "Latest activity" section already showed reading time on the latest post card but not the latest project card. Pass readTime={readingTime(latestProject)} so both cards are consistent and projects show reading time everywhere posts do.

https://claude.ai/code/session_011LDgbS9LK51wvb17z8e5Uy