### PR TITLE
Remove max-height and object-fit constraints from now page images

### DIFF
--- a/src/styles/now.scss
+++ b/src/styles/now.scss
@@ -30,8 +30,6 @@
 	img {
 		width: 100%;
 		height: auto;
-		max-height: 460px;
-		object-fit: cover;
 		border-radius: var(--r-lg);
 		border: 1px solid $line-soft;
 		box-shadow: 0 26px 60px -30px rgba(0, 0, 0, 0.8);


### PR DESCRIPTION
## Summary
Removed CSS constraints that were limiting image display on the now page, allowing images to render at their natural dimensions while maintaining responsive behavior.

## Changes
- Removed `max-height: 460px` constraint from image styling
- Removed `object-fit: cover` property from image styling
- Retained responsive `width: 100%` and `height: auto` for fluid scaling
- Kept border styling, border-radius, and box-shadow effects intact

## Details
Images on the now page will now display at their full height without being constrained to 460px. The `object-fit: cover` property, which was cropping images to fit the container, has also been removed. Images remain responsive and will scale proportionally based on viewport width while maintaining their aspect ratio.

https://claude.ai/code/session_01RkEV54EwcSyzqFVic1Weda